### PR TITLE
feat: add sponsors logos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,7 @@
 dist
 dist-ssr
 node_modules
-# intellij stuff
+
+# IDE folders
 .idea/
-
-# symlink public/assets -> assets repo for local development
-public/assets
-
+.vscode/

--- a/pages/hackathon.md
+++ b/pages/hackathon.md
@@ -6,7 +6,7 @@ description: Contruye al lado de mentores, expertas y hackers la siguiente gener
 ¡Únete al mayor hackathon de Procesamiento del Lenguaje Natural en español!
 
 <div class="flex justify-center">
-    <img src='https://github.com/somosnlp/assets/raw/main/images/hackathon_pln_es_2.png' />
+    <img src='https://github.com/somosnlp/assets/raw/main/images/hackathon_pln_es_3.png' />
 </div>
 
 La democratización del PLN en español es el objetivo principal de nuestra comunidad y una de las mejores maneras de avanzar hacia este objetivo es creando más recursos de PLN en nuestro idioma.
@@ -18,7 +18,7 @@ Con este hackathon te animamos a unirte a nuestro esfuerzo. Te invitamos a entre
 Participar en nuestro hackathon y aplicar tus conocimientos a una buena causa es muy sencillo, ¡anímate!
 
 1. Crea una cuenta en [Hugging Face](https://huggingface.co/join) si todavía no tienes una y regístrate [aquí](./hackathon_wip) 🚀.
-2. Acepta las invitaciones que te mandemos para unirte a nuestra comunidad de Discord y a la organización [hackathon-pln-es](https://huggingface.co/hackathon-pln-es) de Hugging Face.
+2. Únete a nuestra comunidad de [Discord](https://discord.gg/u2wWMHsc) y acepta la invitación que te mandemos para unirte a la organización [hackathon-pln-es](https://huggingface.co/hackathon-pln-es) de Hugging Face.
 3. Echa un vistazo a los diferentes canales de Discord, sobre todo a los de la sección "HACKATHON", ya que iremos anunciando talleres y material con el que preparar el hackathon y también resolveremos las dudas que te puedan surgir durante el evento.
 4. Reúne tu equipo (de 1 a 5 personas) y añádelo a [esta lista](./hackathon_wip). Si todavía no tienes equipo puedes utilizar el canal #encuentra-equipo para crear uno nuevo o unirte a uno existente.
 5. Junto con tu equipo, entrena y sube al [Hub](https://huggingface.co/models) uno o varios modelos. Desde la comunidad queremos animar a todos los equipos a entrenar modelos que sirvan para abordar alguno de los [Objetivos de Desarrollo Sostenible de la ONU](https://www.un.org/sustainabledevelopment/es/objetivos-de-desarrollo-sostenible/).
@@ -32,14 +32,47 @@ Un jurado formado por especialistas en PLN (por anunciar) elegirá los tres equi
 
 ## Charlas y Talleres
 
-Durante el hackathon tendrán lugar diversas charlas y talleres impartidas por profesionales del mundo del Procesamiento del Lenguaje Natural. Iremos anunciando los eventos uno a uno así que atención a [Twitter](https://twitter.com/somosnlp_) y [LinkedIn](https://www.linkedin.com/company/somosnlp)!🔥
+Durante el hackathon tendrán lugar diversas charlas y talleres impartidas por profesionales del mundo del Procesamiento del Lenguaje Natural. Iremos anunciando los eventos uno a uno así que atención a [Twitter](https://twitter.com/somosnlp_) y [LinkedIn](https://www.linkedin.com/company/somosnlp)🔥
 
 <HackathonList />
 
 ## Patrocinadores
 
-<div class="auto-rows-fr grid gap-16 place-items-center lg:grid-cols-3">
-    <img class="w-screen" src='https://huggingface.co/front/assets/huggingface_logo-noborder.svg' />
-    <img class="w-screen" src='https://pbs.twimg.com/profile_images/1297483637227687936/WxoDoICa_400x400.jpg' />
-    <img class="w-screen" src='https://www.spain-ai.com/wp-content/uploads/2021/04/cropped-spain_ai-150x150.png' />    
+Muchísimas gracias por vuestro tiempo y por apoyarnos para que nuestra iniciativa llegue más lejos. ¡Vamos a democratizar el PLN en español!
+
+### 🥇 Platrocinadores de oro
+
+<div class="auto-rows-fr grid gap-x-16 place-items-center lg:grid-cols-3">
+    <a href="https://www.paperspace.com/">
+        <img class="w-screen" src='https://somosnlp.github.io/assets/images/logo_paperspace_black.svg' alt="Paperspace"/>
+    </a>
+    <a href="https://huggingface.co/">
+        <img class="w-screen" src='https://somosnlp.github.io/assets/images/logo_HuggingFace.svg' alt="Hugging Face"/>  
+    </a>
+    <a href="https://www.spain-ai.com/">
+        <img class="w-screen" src="https://somosnlp.github.io/assets/images/logo_SpainAI_black.png" alt="Spain AI"/>  
+    </a>
+</div>
+
+### 🥈 Patrocinadores de plata
+
+<div class="auto-rows-fr grid gap-x-16 place-items-center lg:grid-cols-3">
+    <a href="https://ibidat.es/">
+        <img class="w-screen" src='https://somosnlp.github.io/assets/images/logo_IBiDat.png' />
+    </a>
+    <a href="https://www.narrativa.com/">
+        <img class="w-screen" src="https://somosnlp.github.io/assets/images/logo_Narrativa.png" alt="UNL"/>
+    </a>
+    <a href="https://gplsi.dlsi.ua.es/pln/">
+        <img class="w-screen" src='https://somosnlp.github.io/assets/images/logo_PLNnet.svg' alt="PLN.net" />
+    </a>
+    <a href="https://saturdays.ai/">
+        <img class="w-screen" src="https://somosnlp.github.io/assets/images/logo_SaturdaysAI.png" alt="Saturdays AI"/>
+    </a>
+    <a href="https://www.unam.mx/">
+        <img class="w-screen" src="https://somosnlp.github.io/assets/images/logo_UNAM_dark.png" alt="UNAM"/>
+    </a>
+    <a href="https://www.unl.edu.ec/">
+        <img class="w-screen" src="https://somosnlp.github.io/assets/images/logo_UNL_square.png" alt="UNL"/>
+    </a>
 </div>

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -3,7 +3,7 @@
     <Logo class="col-span-full lg:justify-self-start" />
     <div
       class="text-sm lg:justify-self-start"
-    >© {{ (new Date()).getFullYear() }} nlp-en-es.org All rights reserved.</div>
+    >© {{ (new Date()).getFullYear() }} somosnlp.org All rights reserved.</div>
     <div class="flex flex-wrap gap-2 items-center justify-self-center" text="lg">
       <SocialMediaButtons />
     </div>


### PR DESCRIPTION
- Diferenciar entre patrocinadores de oro y de plata
- Añadir los logos de los nuevos patrocinadores

Quedaría pendiente utilizar la versión clara de los logos cuando está activado el modo oscuro pero al ser un archivo .md es más complicado de lo que me esperaba.

Abro esta PR principalmente para saber si a @oskrmiguel le parece bien utilizar esta versión del logo de la UNL. Me parece que al utilizar la versión horizontal, tanto el logo como la letra no se veían muy bien. En esta versión cuadrada se ve mejor el logo pero si prefieres que utilicemos el horizontal puedo intentar buscar otra opción.