### PR TITLE
Docs: incluir explicación en español 

### DIFF
--- a/locales/README.md
+++ b/locales/README.md
@@ -1,4 +1,14 @@
-## i18n
+## Traducciones
+
+Esta carpeta contiene los archivos YAML para traducir la página web al inglés. Los archivos se cargan automáticamente y sus nombres se registran como códigos de localización (e.g. `es` para español, `en` para inglés).
+
+Para más detalles, ver [`vue-i18n`](https://github.com/intlify/vue-i18n-next).
+
+Si programas en VS Code te recomendamos descargar la extensión [`i18n Ally`](https://github.com/lokalise/i18n-ally).
+
+---
+
+#### EN
 
 This directory is to serve your locale translation files. YAML under this folder would be loaded automatically and register with their filenames as locale code.
 


### PR DESCRIPTION
Resolves #37 

- No se puede renombrar la carpeta "locales" 
- He explicado en el README la función de la carpeta