### PR TITLE
Fix #77 / La previsualización al compartir el enlace a la página web no muestra la imagen

### DIFF
--- a/pages/empleo/index.vue
+++ b/pages/empleo/index.vue
@@ -11,7 +11,7 @@ useHead({
     meta: [
         { property: 'og:title', content: 'Bolsa de Empleo NLP' },
         { property: 'og:description', content: 'Ofertas de empleo e investigación en el ámbito del PLN.' },
-        { property: 'og:image', content: 'https://somosnlp.github.io/assets/logo.svg' },
+        { property: 'og:image', content: 'https://somosnlp.github.io/assets/logo.png' },
         { name: 'twitter:card', content: 'summary' },
         { name: 'twitter:site', content: '@somosnlp_' },
         { name: 'twitter:creator', content: '@somosnlp_' },

--- a/pages/hackathon/index.vue
+++ b/pages/hackathon/index.vue
@@ -6,7 +6,7 @@ useHead({
     meta: [
         { property: 'og:title', content: 'Hackathon Somos NLP 2022' },
         { property: 'og:description', content: '¡Únete al mayor hackathon open-source de Procesamiento del Lenguaje Natural en español!' },
-        { property: 'og:image', content: 'https://github.com/somosnlp/assets/raw/main/images/hackathon_pln_es_3.png' },
+        { property: 'og:image', content: 'https://somosnlp.github.io/assets/images/hackathon_pln_es_3.png' },
         { name: 'twitter:card', content: 'summary' },
         { name: 'twitter:site', content: '@somosnlp_' },
         { name: 'twitter:creator', content: '@somosnlp_' },

--- a/pages/recursos/index.vue
+++ b/pages/recursos/index.vue
@@ -6,7 +6,7 @@ useHead({
     meta: [
         { property: 'og:title', content: 'Somos NLP - Recursos open-source de NLP en español' },
         { property: 'og:description', content: '¡Fórmate con el equipo de Somos NLP!' },
-        { property: 'og:image', content: 'https://somosnlp.github.io/assets/logo.svg' },
+        { property: 'og:image', content: 'https://github.com/somosnlp/assets/raw/main/logo.png' },
         { name: 'twitter:card', content: 'summary' },
         { name: 'twitter:site', content: '@somosnlp_' },
         { name: 'twitter:creator', content: '@somosnlp_' },

--- a/src/components/BlogPost.vue
+++ b/src/components/BlogPost.vue
@@ -30,7 +30,7 @@ useHead({
             content: computed(
                 () => frontmatter.cover
                     ? frontmatter.cover
-                    : 'https://somosnlp.github.io/assets/logo.png')
+                    : 'https://github.com/somosnlp/assets/raw/main/logo.png')
         },
         { name: 'twitter:card', content: 'summary' },
         { name: 'twitter:site', content: '@somosnlp_' },


### PR DESCRIPTION
1. Twitter Cards no aceptan SVG como formato para la imagen