### PR TITLE
docs(recursos;open-source): Actualizacion listado datasets

### DIFF
--- a/pages/recursos/open-source/datasets.md
+++ b/pages/recursos/open-source/datasets.md
@@ -7,7 +7,7 @@ cover: "https://somosnlp.github.io/assets/images/undraw_education_edited.svg"
 <ResourceItem
     name="Catalonia Independence Corpus"
     :tags="['clasificación de sentimientos']"
-    description="Esta base de datos contiene dos corpus en español y catalán que contienen mensajes de Twitter anotados para la detección de opiniones. Cada corpus está anotado con tres posturas\: 'against', 'favor' y 'neutral' (a favor, en contra, neutral) respecto a la independencia de Cataluña."
+    description="Esta base de datos contiene dos corpus en español y catalán que contienen mensajes de Twitter anotados para la detección de opiniones. Cada corpus está anotado con tres posturas: 'against', 'favor' y 'neutral' (a favor, en contra, neutral) respecto a la independencia de Cataluña."
     website
     github="https://github.com/ixa-ehu/catalonia-independence-corpus"
     paper="https://www.aclweb.org/anthology/2020.lrec-1.171/"
@@ -91,6 +91,137 @@ cover: "https://somosnlp.github.io/assets/images/undraw_education_edited.svg"
     paper="https://www.cs.upc.edu/~nlp/papers/reese10.pdf"
     hf_dataset_name="wikicorpus" 
     hf_contributor_handle="albertvillanova"
+/>
+
+---
+
+
+<ResourceItem
+    name="InfoLibros Corpus"
+    :tags="['modelado del lenguaje']"
+    description="El corpus InfoLibros es un corpus de 218 millones de tokens de narraciones en español extraídas de libros gratuitos recopilados por el proyecto abierto Infolibros.org. El corpus se ha preprocesado y depurado mediante el procedimiento de Corpus-Cleaner."
+    website='https://doi.org/10.5281/zenodo.7313105'
+    github
+    paper
+    hf_dataset_name
+    hf_contributor_handle
+/>
+
+---
+
+<ResourceItem
+    name="Spanish CBOW Word Embeddings in Floret"
+    :tags="['modelado del lenguaje','CBOW (Continuous Bag Of Words)']"
+    description="Dataset compuesto por embeddings entrenados con el corpus de la Biblioteca Nacional de España (BNE) utilizando floret."
+    website='https://doi.org/10.5281/zenodo.7314098'
+    github
+    paper
+    hf_dataset_name
+    hf_contributor_handle
+/>
+
+---
+
+<ResourceItem
+    name="Biomedical Spanish CBOW Word Embeddings in Floret"
+    :tags="['modelado del lenguaje','CBOW (Continuous Bag Of Words)']"
+    description="Dataset compuesto por embeddings entrenados en la combinación de todos los textos presentes en el corpus biomédico español, que incluye datos de múltiples fuentes para un total de 1.1B tokens a través de 2,5M de documentos."
+    website='https://doi.org/10.5281/zenodo.7314041'
+    github
+    paper
+    hf_dataset_name
+    hf_contributor_handle
+/>
+
+---
+
+<ResourceItem
+    name="TDX Thesis Spanish Corpus"
+    :tags="['modelado del lenguaje']"
+    description="El corpus TDX Thesis Spanish es un corpus de 246 millones de tokens de texto limpio en español extraído de tesis científicas del dominio tdx.cat, que contiene tesis abiertas publicadas por universidades catalanas. El corpus se ha preprocesado y depurado mediante el procedimiento de Corpus-Cleaner."
+    website='https://doi.org/10.5281/zenodo.7313149'
+    github
+    paper
+    hf_dataset_name
+    hf_contributor_handle
+/>
+
+---
+
+<ResourceItem
+    name="CSIC Spanish Corpus"
+    :tags="['modelado del lenguaje']"
+    description="El corpus español de CSIC es un corpus de 146 millones de tokens de revistas científicas españolas del repositorio revistas.csic.es/. El corpus se ha preprocesado y depurado mediante el procedimiento de Corpus-Cleaner."
+    website='https://doi.org/10.5281/zenodo.7313126'
+    github
+    paper
+    hf_dataset_name
+    hf_contributor_handle
+/>
+
+---
+
+<ResourceItem
+    name="BasCrawl"
+    :tags="['modelado del lenguaje']"
+    description="BasCrawl es un corpus web de 186 millones de tokens en euskera (basque) obtenido mediante el análisis de más de 12000 dominios en internet [Se incluyen los dominios analizados]. El corpus ha sido preprocesado y depurado."
+    website='https://doi.org/10.5281/zenodo.7313092'
+    github
+    paper
+    hf_dataset_name
+    hf_contributor_handle
+/>
+
+---
+
+<ResourceItem
+    name="Spanish Legal Domain Corpora"
+    :tags="['modelado del lenguaje']"
+    description="Dataset compuesto por una colección de textos (corpus) del ámbito jurídico español."
+    website='https://doi.org/10.5281/zenodo.5495529'
+    github='https://github.com/PlanTL-GOB-ES/lm-legal-es'
+    paper='https://arxiv.org/abs/2110.12201'
+    hf_dataset_name
+    hf_contributor_handle
+/>
+
+---
+
+<ResourceItem
+    name="Spanish Skip-Gram Word Embeddings in FastText"
+    :tags="['modelado del lenguaje','FastText']"
+    description="El corpus cuenta con más de 2TB de texto de alta calidad, recopilado a partir de los diferentes análisis web realizados por la Biblioteca Nacional de España desde 2009 hasta 2019. Dataset compuesto exclusivamente por embeddings Skip-Gram."
+    website='https://doi.org/10.5281/zenodo.5046525'
+    github
+    paper='http://journal.sepln.org/sepln/ojs/ojs/index.php/pln/article/view/6405'
+    hf_dataset_name
+    hf_contributor_handle
+/>
+
+---
+
+<ResourceItem
+    name="Spanish CBOW Word Embeddings in FastText"
+    :tags="['modelado del lenguaje','FastText']"
+    description="Embeddings de palabras en español en FastText generados a partir del mayor corpus realizado en español hasta la fecha. El corpus cuenta con más de 2 TB de texto de alta calidad, recopilado a partir de los diferentes rastreos web realizados por la Biblioteca Nacional de España entre 2009 y 2019. Dataset compuesto exclusivamente por CBOW embeddings."
+    website='https://doi.org/10.5281/zenodo.5044988'
+    github
+    paper='http://journal.sepln.org/sepln/ojs/ojs/index.php/pln/article/view/6405'
+    hf_dataset_name
+    hf_contributor_handle
+/>
+
+---
+
+<ResourceItem
+    name="Spanish Legal Domain Word & Sub-Word Embeddings"
+    :tags="['modelado del lenguaje']"
+    description="Conjunto de embeddings generados a partir del corpus compuesto de recursos jurídicos españoles mas grande hasta la fecha (9GB)."
+    website='https://doi.org/10.5281/zenodo.5036147'
+    github='https://github.com/PlanTL-GOB-ES/lm-legal-es'
+    paper='https://arxiv.org/abs/2110.12201'
+    hf_dataset_name
+    hf_contributor_handle
 />
 
 ---

--- a/pages/recursos/open-source/datasets.md
+++ b/pages/recursos/open-source/datasets.md
@@ -95,7 +95,6 @@ cover: "https://somosnlp.github.io/assets/images/undraw_education_edited.svg"
 
 ---
 
-
 <ResourceItem
     name="InfoLibros Corpus"
     :tags="['modelado del lenguaje']"
@@ -125,10 +124,23 @@ cover: "https://somosnlp.github.io/assets/images/undraw_education_edited.svg"
 <ResourceItem
     name="Biomedical Spanish CBOW Word Embeddings in Floret"
     :tags="['modelado del lenguaje','CBOW (Continuous Bag Of Words)']"
-    description="Dataset compuesto por embeddings entrenados en la combinación de todos los textos presentes en el corpus biomédico español, que incluye datos de múltiples fuentes para un total de 1.1B tokens a través de 2,5M de documentos."
+    description="Dataset compuesto por embeddings entrenados en la combinación de todos los textos presentes en el corpus biomédico español, que incluye datos de múltiples fuentes para un total de 1100M tokens a través de 2,5M de documentos."
     website='https://doi.org/10.5281/zenodo.7314041'
     github
-    paper
+    paper='https://arxiv.org/abs/2109.07765'
+    hf_dataset_name
+    hf_contributor_handle
+/>
+
+---
+
+<ResourceItem
+    name="Spanish Biomedical Crawled Corpus"
+    :tags="['modelado del lenguaje']"
+    description="El mayor corpus biomédico y de salud en español hasta la fecha, recopilado a partir de un análisis web masivo de dominios de salud españoles en más de 3.000 URL. Todos los datos recopilados se han preprocesado para producir el recurso CoWeSe (Corpus Web Salud Español)."
+    website='https://doi.org/10.5281/zenodo.5513237'
+    github
+    paper='https://arxiv.org/abs/2109.07765'
     hf_dataset_name
     hf_contributor_handle
 />
@@ -164,7 +176,7 @@ cover: "https://somosnlp.github.io/assets/images/undraw_education_edited.svg"
 <ResourceItem
     name="BasCrawl"
     :tags="['modelado del lenguaje']"
-    description="BasCrawl es un corpus web de 186 millones de tokens en euskera (basque) obtenido mediante el análisis de más de 12000 dominios en internet [Se incluyen los dominios analizados]. El corpus ha sido preprocesado y depurado."
+    description="BasCrawl es un corpus web de 186 millones de tokens en euskera obtenido mediante el análisis de más de 12000 dominios en internet (se incluyen los dominios analizados). El corpus ha sido preprocesado y depurado siguiendo el mismo procedimiento que MarIA."
     website='https://doi.org/10.5281/zenodo.7313092'
     github
     paper


### PR DESCRIPTION
- Relacionado al Issue #56 
- Información obtenida de [Zendoo.org](https://zenodo.org/communities/spanish-ai/?page=1&size=20)
- Resumen de cambios:
  - Correción tipográfica.
  - Se agregaron 10 nuevos datasets de acuerdo con la información disponible:
      - InfoLibros Corpus, Spanish CBOW Word Embeddings in Floret, Biomedical Spanish CBOW Word Embeddings in Floret, TDX Thesis Spanish Corpus,  CSIC Spanish Corpus, BasCrawl, Spanish Legal Domain Corpora, Spanish CBOW Word Embeddings in FastText, Spanish Legal Domain Word & Sub-Word Embeddings.