### PR TITLE
Increase prose max-width for markdown pages

### DIFF
--- a/windi.config.ts
+++ b/windi.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
       typography: {
         DEFAULT: {
           css: {
-            maxWidth: '65ch',
+            maxWidth: '90ch',
             color: 'inherit',
             a: {
               'color': 'inherit',


### PR DESCRIPTION
Bumps the Windi typography DEFAULT maxWidth from 65ch to 90ch so
markdown-rendered content (blog posts, legal pages, etc. wrapped by
BlogPost.vue's `.prose` article) uses more of the available viewport
instead of being constrained to a narrow ~65-character column.

https://claude.ai/code/session_01XwhuDzo1rV3QL9RReSTbYi