### PR TITLE
content(hackathon): translate hackathon content to EN and PT

### DIFF
--- a/pages/hackathon/cartel.en.md
+++ b/pages/hackathon/cartel.en.md
@@ -1,0 +1,36 @@
+---
+title: "Hackathon SomosNLP 2026: Design the Poster"
+description: "Design the poster for Hackathon SomosNLP 2026!"
+lang: en
+cover: /images/eventos/260401_hackathon_sinfecha.jpg
+---
+
+To foster different skills within our community, this year we want to give you the opportunity to design the hackathon poster. The goals of the hackathon are to create a quality Spanish corpus that captures the varieties of this rich language spoken by 600M people and to build a leaderboard that lets us evaluate LLMs in Spanish. Show us your most artistic side and help us create the poster!
+
+## 🎨 How to participate
+
+1. Design a poster (or several)
+2. [Send it to us](https://forms.gle/iJrKZtBXvnAk5Ji38) before March 13
+3. We will publicly thank every submission (if you want, of course)
+4. If you win, your poster will be the image of the 2026 hackathon!
+
+## ✅ What the poster must include
+
+- Dimensions: 1280 × 720 minimum with 16:9 aspect ratio (landscape)
+- Title: Hackathon SomosNLP 2026
+- Edition: IV
+- Date: March 17 to April 13, 2026
+- Website: somosnlp.org/hackathon
+- #HackathonSomosNLP
+- [SomosNLP Logo](/images/patrocinios/somos_nlp.png)
+
+## 📝 Notes
+
+- Creations must be original
+- You can use any type of design tool, including AI systems
+- You will need to be transparent about any use of AI
+- Everyone's participation will be publicly acknowledged
+
+We can't wait to see your posters! 🤩
+
+<!-- Idea: Twitter thread with posters in order of submission -->

--- a/pages/hackathon/cartel.pt.md
+++ b/pages/hackathon/cartel.pt.md
@@ -1,0 +1,36 @@
+---
+title: "Hackathon SomosNLP 2026: Desenhe o Cartaz"
+description: "Desenhe o cartaz do Hackathon SomosNLP 2026!"
+lang: pt
+cover: /images/eventos/260401_hackathon_sinfecha.jpg
+---
+
+Para incentivar diferentes habilidades da nossa comunidade, este ano queremos dar a você a oportunidade de desenhar o cartaz do hackathon. Os objetivos do hackathon são a criação de um corpus em espanhol de qualidade que inclua as variedades desse rico idioma falado por 600M de pessoas e a criação de uma leaderboard que nos permita avaliar os LLMs em espanhol. Mostre seu lado mais artístico e nos ajude a criar o cartaz!
+
+## 🎨 Como participar
+
+1. Desenhe um cartaz (ou vários)
+2. [Envie-nos](https://forms.gle/iJrKZtBXvnAk5Ji38) antes de 13 de março
+3. Agradeceremos publicamente todas as propostas (se você quiser, claro)
+4. Se ganhar, seu cartaz será a imagem do hackathon 2026!
+
+## ✅ O que o cartaz precisa incluir
+
+- Dimensões: 1280 × 720 no mínimo com proporção 16:9 (horizontal)
+- Título: Hackathon SomosNLP 2026
+- Edição: IV
+- Data: 17 de março a 13 de abril de 2026
+- Site: somosnlp.org/hackathon
+- #HackathonSomosNLP
+- [Logo da SomosNLP](/images/patrocinios/somos_nlp.png)
+
+## 📝 Notas
+
+- As criações devem ser originais
+- É permitido o uso de qualquer tipo de ferramenta de design, incluindo sistemas de IA
+- Será necessário ser transparente quanto ao uso de IA
+- A participação de todos será agradecida publicamente
+
+Mal podemos esperar pelos seus cartazes! 🤩
+
+<!-- Idea: Thread no Twitter com os cartazes por ordem de envio -->

--- a/pages/hackathon/ediciones-anteriores.en.md
+++ b/pages/hackathon/ediciones-anteriores.en.md
@@ -1,0 +1,173 @@
+---
+title: "#HackathonSomosNLP"
+description: Join the largest open-source Natural Language Processing hackathon in Spanish and Portuguese
+lang: en
+cover: /images/eventos/260401_hackathon_sinfecha.jpg
+---
+
+There are 600M Spanish speakers and 265M Portuguese speakers in the world. Spanish and Portuguese are the main languages in 29 countries, each of them rich in culture. Although language models show ever-growing multilingual capabilities, are they truly multicultural?
+
+Join the #HackathonSomosNLP, an international online competition whose main goal is to **create diverse and open NLP resources for the languages of Ibero-America** 🚀
+
+<center><a href="/en/hackathon" target="_blank" style="background-color:#FACC15; color:white; padding:10px 20px; text-decoration:none; border-radius:5px;">Hackathon 2026</a></center>
+
+This year we are celebrating the fifth edition — curious about the results from previous years? Read on!
+
+---
+
+# Winning projects
+
+## Hackathon SomosNLP 2025: Cultural Alignment
+
+The top three corpora in the preferences challenge are:
+- 🥇 TralaleloTralala-MemeAlign
+- 🥈 IberoTales
+- 🥉 HoCV-COL
+
+Finalist teams:
+- 👏 Comida Colombia + Ecuador
+- 👏 Cresia
+- 👏 Equipo LeIA
+- 👏 Falsos Amigos
+- 👏 Refranero Afro-Cubano
+- 👏 Sabiduría Popular Castellana
+- 👏 Think Paraguayo
+
+Notable collective achievements:
+- 📚 INCLUDE: 38,000+ exam questions from 23 countries
+- 📚 BLEND: extension of the cultural-knowledge benchmark
+- 📚 ~1,000 stereotypes collected and validated
+
+[More information about the Hackathon 2025 projects](/en/blog/hackathon-2025)
+
+## Hackathon SomosNLP 2024: #Somos600M
+
+The three winning projects are:
+- 🥇 NoticIA: Clickbait News Summarization
+- 🥈 AsistenciaRefugiados: Legal assistance for refugees
+- 🥉 TraductorInclusivo: Text rewriting using inclusive language
+
+And the community's favorite project is:
+- 💛 AviaciónInteligente: Navigating the Colombian Aeronautical Regulations
+
+Special mentions to the projects:
+- 👏 ThinkParaguayo: Discover Guaraní culture
+- 👏 LenguajeClaro: Administrative language simplification
+- 👏 BERTIN-ClimID: BERTIN-Base Climate-related text Identification
+
+And to the corpora:
+- 📚 SMC: Spanish Medical Corpus
+- 📚 RecetasDeLaAbuel@: A recipe corpus from Spanish-speaking countries
+- 📚 LingComp_QA: An educational computational-linguistics corpus in Spanish
+- 📚 KUNTUR: Peruvian Political Constitution of 1993
+- 📚 Province identification and summaries from the Rural Spanish Oral and Sound Corpus
+
+
+## Hackathon SomosNLP 2023: LLMs in Spanish
+
+In this second edition, more than 500 people from 30 countries participated and developed 22 projects and 3 published papers.
+
+[More information about Hackathon 2023](/en/blog/hackathon-2023)
+
+## Hackathon SomosNLP 2022: NLP in Spanish
+
+In the first edition, more than 500 people from 29 countries participated. Featured projects:
+- 🥇 [BiomedIA](https://www.youtube.com/watch?v=fOQLPuXewzE&list=PLTA-KAy8nxaAbyaBTYK68TZKQLv9V8L8M): a voice-to-voice biomedical Q&A system, which led to a [paper presented at NAACL 2022](https://research.latinxinai.org/papers/naacl/2022/pdf/paper_06.pdf) that won the Best Poster Presentation Award
+- 🥈 [Mexican Legal Model](https://www.youtube.com/watch?v=ZTYAsEHUhPs&list=PLTA-KAy8nxaAbyaBTYK68TZKQLv9V8L8M): a model used by the **Supreme Court of Justice of Mexico**
+- 🥉 [Gender Neutralization](https://www.youtube.com/watch?v=XOaQKNauySo&list=PLTA-KAy8nxaAbyaBTYK68TZKQLv9V8L8M): rewriting texts in an inclusive way
+- 💜 [Sexism Detector](https://www.youtube.com/watch?v=1LmH6lblxvg&list=PLTA-KAy8nxaAbyaBTYK68TZKQLv9V8L8M): a contribution to removing sexist comments
+
+[More information about Hackathon 2022](/en/blog/hackathon-2022)
+
+---
+
+# Published papers
+
+The hackathon projects and the community's collective achievements have led to the following papers:
+
+- Grandury, M., Aula-Blasco, J., Falcão, J., Fourrier, C., González, M., Martínez, G. & Santamaría, G., ... (2025). *La Leaderboard: A Large Language Model Leaderboard for Spanish Varieties and Languages of Spain and Latin America*, ACL Main.
+- Salazar, I., Fernández Burda, M., Bin Islam, S., Soltani Moakhar, A., Singh, S., Farestam, F., Romanou, A., ... Grandury, M. ... (2025). *Kaleidoscope: In-language Exams for Massively Multilingual Vision Evaluation*, ICLR.
+- Grandury, M. (2024). *The #Somos600M Project: Generating NLP resources that represent the diversity of the languages from LATAM, the Caribbean, and Spain*. LatinX in AI (LXAI) Research Workshop @NAACL 2024.
+- Mayor-Rocher, M., Melero, N., Merino-Gómez, E., Grandury, M., Conde, J., & Reviriego, P. (2024). *Evaluating large language models with tests of Spanish as a foreign language: Pass or fail?*
+- Plaza, I., Melero, N., del Pozo, C., Conde, J., Reviriego, P., Mayor-Rocher, M., & Grandury, M. (2024). *Spanish and LLM Benchmarks: Is MMLU lost in translation?*
+- García-Ferrero, I., & Altuna, B. (2024). *NoticIA: A Clickbait Article Summarization Dataset in Spanish*. Procesamiento del Lenguaje Natural, 73, 191-207.
+- Huerta, G. & Zuñiga Rojas, G. (2024). *Identificación de textos relacionados al cambio climático y sustentabilidad utilizando modelos de lenguaje preentrenados en español*. LatinX in AI (LXAI) Research Workshop @NAACL 2024.
+- Morales-Garzón, A., Benel Ramirez, S., Tuco Casquino, G., A. Rocha, O., & Medina, A. (2024). *Aprendiendo a cocinar de manera saludable con Large Language Models, Supervised Fine Tuning y Retrieval Augmented Generation*. LatinX in AI (LXAI) Research Workshop @NAACL 2024.
+- Jair Bejarano Sepulveda, E., Nicolai Potes Patiño, H., Pineda Montoya, S., Ivan Rodriguez, F., Enrique Orduy, J., Stevens Traslaviña, D., Mauricio Rosales, A. & Nicolás Madrid, S. (2024). *Towards Improved RAC Accessibility: Dataset and LLMs, approach to enhancing RAC accessibility*. LatinX in AI (LXAI) Research Workshop @NAACL 2024.
+
+---
+
+# Talks and workshops
+
+## Hackathon 2025
+
+<div class="grid grid-cols-3 gap-8 my-8">
+    <a href="https://www.youtube.com/playlist?list=PLTA-KAy8nxaDHyJyPlrDMCkwTsJZpMNK6" target="_blank">
+        <img alt="Talk by Selene Baez" width="650" height="365"
+        src="/images/eventos/250410_selene_baez.png" />
+    </a>
+    <a href="https://www.youtube.com/playlist?list=PLTA-KAy8nxaDHyJyPlrDMCkwTsJZpMNK6" target="_blank">
+        <img alt="Talk by Alfonso Amayuelas" width="650" height="365"
+        src="/images/eventos/250415_alfonso_amayuelas.png" />
+    </a>
+    <a href="https://www.youtube.com/playlist?list=PLTA-KAy8nxaDHyJyPlrDMCkwTsJZpMNK6" target="_blank">
+        <img alt="Talk by Andrés Marafioti" width="650" height="365"
+        src="/images/eventos/250422_andres_marafioti.png" />
+    </a>
+</div>
+
+## Hackathon 2024
+
+<div class="grid grid-cols-3 gap-8 my-8">
+    <a href="/hackathon-2024/ia_y_lms_retos_y_oportunidades" target="_blank">
+        <img alt="Talk by Elena González-Blanco" width="650" height="365"
+        src="/images/eventos/240307_elena_gonzalez_blanco.png" />
+    </a>
+    <a href="/hackathon-2024/crear_datasets_de_calidad_con_argilla_y_distilabel" target="_blank">
+        <img alt="Talk by Gabriel Martín" width="650" height="365"
+        src="/images/eventos/240311_gabriel_martin_blazquez.jpg" />
+    </a>
+    <a href="/hackathon-2024/empatia_y_emociones_en_ia" target="_blank">
+        <img alt="Talk by Amanda Curry" width="650" height="365"
+        src="/images/eventos/240326_amanda_curry.jpg" />
+    </a>
+</div>
+
+## Hackathon 2023
+
+<div class="grid grid-cols-3 gap-8 my-8">
+    <a href="/hackathon-2023/fine-tuning-llms" target="_blank">
+        <img alt="Fine-tuning large language models" width="650" height="365"
+        src="/images/eventos/230320_fine_tuning_llms.jpg" />
+    </a>
+    <a href="/hackathon-2023/deteccion-del-lenguaje-ofensivo" target="_blank">
+        <img alt="Offensive language detection" width="650" height="365"
+        src="/images/eventos/230404_deteccion_del_lenguaje_ofensivo.jpg" />
+    </a>
+    <a href="/hackathon-2023/evaluacion-con-desacuerdo" target="_blank">
+        <img alt="Evaluation with disagreement" width="650" height="365"
+        src="/images/eventos/230404_evaluacion_con_desacuerdo.jpg" />
+    </a>
+</div>
+
+## Hackathon 2022
+
+<div class="grid grid-cols-3 gap-8 my-8">
+    <a href="https://www.youtube.com/watch?v=GX4l3WhOy4o&list=PLTA-KAy8nxaAbVZ2lVcycHnJ2qEDip7hG" target="_blank">
+        <img alt="Event 04" width="650" height="365"
+        src="/images/eventos/220323_cristina.png" />
+    </a>
+    <a href="https://www.youtube.com/watch?v=UQwWTykNFW0&list=PLTA-KAy8nxaAbVZ2lVcycHnJ2qEDip7hG" target="_blank">
+        <img alt="Event 05" width="650" height="365"
+        src="/images/eventos/220323_paulo.png" />
+    </a>
+    <a href="https://www.youtube.com/watch?v=aNR7UM-E6vA&list=PLTA-KAy8nxaAbVZ2lVcycHnJ2qEDip7hG" target="_blank">
+        <img alt="Event 06" width="650" height="365"
+        src="/images/eventos/220330_ximena.png" />
+    </a>
+</div>
+
+<router-link to="/en/eventos" class="button-accent max-w-100 mx-auto">
+<Carbon:logoYoutube text="xl" />
+See all events
+</router-link>

--- a/pages/hackathon/ediciones-anteriores.pt.md
+++ b/pages/hackathon/ediciones-anteriores.pt.md
@@ -1,0 +1,173 @@
+---
+title: "#HackathonSomosNLP"
+description: Participe do maior hackathon open-source de Processamento de Linguagem Natural em espanhol e português
+lang: pt
+cover: /images/eventos/260401_hackathon_sinfecha.jpg
+---
+
+Somos 600M de pessoas que falam espanhol e 265M que falam português no mundo. O espanhol e o português são os idiomas principais em 29 países, cada um com uma grande riqueza cultural. Embora os modelos de linguagem apresentem capacidades multilíngues cada vez maiores, eles são realmente multiculturais?
+
+Participe do #HackathonSomosNLP, uma competição internacional online cujo principal objetivo é **criar recursos diversos e abertos de PLN para as línguas da Ibero-América** 🚀
+
+<center><a href="/pt/hackathon" target="_blank" style="background-color:#FACC15; color:white; padding:10px 20px; text-decoration:none; border-radius:5px;">Hackathon 2026</a></center>
+
+Este ano celebramos a quinta edição. Tem curiosidade sobre os resultados dos anos anteriores? Continue lendo!
+
+---
+
+# Projetos vencedores
+
+## Hackathon SomosNLP 2025: Adequação Cultural
+
+Os três melhores corpora do desafio de preferências são:
+- 🥇 TralaleloTralala-MemeAlign
+- 🥈 IberoTales
+- 🥉 HoCV-COL
+
+Equipes finalistas:
+- 👏 Comida Colombia + Ecuador
+- 👏 Cresia
+- 👏 Equipo LeIA
+- 👏 Falsos Amigos
+- 👏 Refranero Afro-Cubano
+- 👏 Sabiduría Popular Castellana
+- 👏 Think Paraguayo
+
+Conquistas coletivas em destaque:
+- 📚 INCLUDE: mais de 38.000 perguntas de exames de 23 países
+- 📚 BLEND: extensão do benchmark de conhecimento cultural
+- 📚 ~1.000 estereótipos coletados e validados
+
+[Mais informações sobre os projetos do Hackathon 2025](/pt/blog/hackathon-2025)
+
+## Hackathon SomosNLP 2024: #Somos600M
+
+Os três projetos vencedores são:
+- 🥇 NoticIA: Resumo de Notícias Clickbait
+- 🥈 AsistenciaRefugiados: Assistência jurídica para refugiados
+- 🥉 TraductorInclusivo: Reescrita de textos utilizando linguagem inclusiva
+
+E o projeto favorito da comunidade é:
+- 💛 AviaciónInteligente: Navegação pelo Regulamento Aeronáutico Colombiano
+
+Menção especial aos projetos:
+- 👏 ThinkParaguayo: Conheça a cultura guarani
+- 👏 LenguajeClaro: Simplificação da linguagem administrativa
+- 👏 BERTIN-ClimID: BERTIN-Base Climate-related text Identification
+
+E aos corpora:
+- 📚 SMC: Spanish Medical Corpus
+- 📚 RecetasDeLaAbuel@: Corpus de receitas de países hispano-americanos
+- 📚 LingComp_QA: Um corpus educacional de linguística computacional em espanhol
+- 📚 KUNTUR: Constituição política do Peru de 1993
+- 📚 Identificação de províncias e resumos do Corpus Oral e Sonoro do Espanhol Rural
+
+
+## Hackathon SomosNLP 2023: LLMs em espanhol
+
+Nesta segunda edição, mais de 500 pessoas de 30 países participaram e desenvolveram 22 projetos e 3 papers publicados.
+
+[Mais informações sobre o Hackathon 2023](/pt/blog/hackathon-2023)
+
+## Hackathon SomosNLP 2022: PLN em espanhol
+
+Na primeira edição, mais de 500 pessoas de 29 países participaram. Projetos em destaque:
+- 🥇 [BiomedIA](https://www.youtube.com/watch?v=fOQLPuXewzE&list=PLTA-KAy8nxaAbyaBTYK68TZKQLv9V8L8M): sistema voz-a-voz de Q&A biomédico, que resultou em um [paper apresentado no NAACL 2022](https://research.latinxinai.org/papers/naacl/2022/pdf/paper_06.pdf) com o Prêmio de Melhor Apresentação de Pôster
+- 🥈 [Modelo Jurídico Mexicano](https://www.youtube.com/watch?v=ZTYAsEHUhPs&list=PLTA-KAy8nxaAbyaBTYK68TZKQLv9V8L8M): modelo utilizado pela **Suprema Corte de Justiça da Nação do México**
+- 🥉 [Neutralização de gênero](https://www.youtube.com/watch?v=XOaQKNauySo&list=PLTA-KAy8nxaAbyaBTYK68TZKQLv9V8L8M): reescrita de textos de forma inclusiva
+- 💜 [Detector de sexismo](https://www.youtube.com/watch?v=1LmH6lblxvg&list=PLTA-KAy8nxaAbyaBTYK68TZKQLv9V8L8M): contribuição para a eliminação de comentários sexistas
+
+[Mais informações sobre o Hackathon 2022](/pt/blog/hackathon-2022)
+
+---
+
+# Papers publicados
+
+Os projetos do hackathon e as conquistas coletivas da comunidade resultaram nos seguintes papers:
+
+- Grandury, M., Aula-Blasco, J., Falcão, J., Fourrier, C., González, M., Martínez, G. & Santamaría, G., ... (2025). *La Leaderboard: A Large Language Model Leaderboard for Spanish Varieties and Languages of Spain and Latin America*, ACL Main.
+- Salazar, I., Fernández Burda, M., Bin Islam, S., Soltani Moakhar, A., Singh, S., Farestam, F., Romanou, A., ... Grandury, M. ... (2025). *Kaleidoscope: In-language Exams for Massively Multilingual Vision Evaluation*, ICLR.
+- Grandury, M. (2024). *The #Somos600M Project: Generating NLP resources that represent the diversity of the languages from LATAM, the Caribbean, and Spain*. LatinX in AI (LXAI) Research Workshop @NAACL 2024.
+- Mayor-Rocher, M., Melero, N., Merino-Gómez, E., Grandury, M., Conde, J., & Reviriego, P. (2024). *Evaluating large language models with tests of Spanish as a foreign language: Pass or fail?*
+- Plaza, I., Melero, N., del Pozo, C., Conde, J., Reviriego, P., Mayor-Rocher, M., & Grandury, M. (2024). *Spanish and LLM Benchmarks: Is MMLU lost in translation?*
+- García-Ferrero, I., & Altuna, B. (2024). *NoticIA: A Clickbait Article Summarization Dataset in Spanish*. Procesamiento del Lenguaje Natural, 73, 191-207.
+- Huerta, G. & Zuñiga Rojas, G. (2024). *Identificación de textos relacionados al cambio climático y sustentabilidad utilizando modelos de lenguaje preentrenados en español*. LatinX in AI (LXAI) Research Workshop @NAACL 2024.
+- Morales-Garzón, A., Benel Ramirez, S., Tuco Casquino, G., A. Rocha, O., & Medina, A. (2024). *Aprendiendo a cocinar de manera saludable con Large Language Models, Supervised Fine Tuning y Retrieval Augmented Generation*. LatinX in AI (LXAI) Research Workshop @NAACL 2024.
+- Jair Bejarano Sepulveda, E., Nicolai Potes Patiño, H., Pineda Montoya, S., Ivan Rodriguez, F., Enrique Orduy, J., Stevens Traslaviña, D., Mauricio Rosales, A. & Nicolás Madrid, S. (2024). *Towards Improved RAC Accessibility: Dataset and LLMs, approach to enhancing RAC accessibility*. LatinX in AI (LXAI) Research Workshop @NAACL 2024.
+
+---
+
+# Palestras e workshops
+
+## Hackathon 2025
+
+<div class="grid grid-cols-3 gap-8 my-8">
+    <a href="https://www.youtube.com/playlist?list=PLTA-KAy8nxaDHyJyPlrDMCkwTsJZpMNK6" target="_blank">
+        <img alt="Palestra de Selene Baez" width="650" height="365"
+        src="/images/eventos/250410_selene_baez.png" />
+    </a>
+    <a href="https://www.youtube.com/playlist?list=PLTA-KAy8nxaDHyJyPlrDMCkwTsJZpMNK6" target="_blank">
+        <img alt="Palestra de Alfonso Amayuelas" width="650" height="365"
+        src="/images/eventos/250415_alfonso_amayuelas.png" />
+    </a>
+    <a href="https://www.youtube.com/playlist?list=PLTA-KAy8nxaDHyJyPlrDMCkwTsJZpMNK6" target="_blank">
+        <img alt="Palestra de Andrés Marafioti" width="650" height="365"
+        src="/images/eventos/250422_andres_marafioti.png" />
+    </a>
+</div>
+
+## Hackathon 2024
+
+<div class="grid grid-cols-3 gap-8 my-8">
+    <a href="/hackathon-2024/ia_y_lms_retos_y_oportunidades" target="_blank">
+        <img alt="Palestra de Elena González-Blanco" width="650" height="365"
+        src="/images/eventos/240307_elena_gonzalez_blanco.png" />
+    </a>
+    <a href="/hackathon-2024/crear_datasets_de_calidad_con_argilla_y_distilabel" target="_blank">
+        <img alt="Palestra de Gabriel Martín" width="650" height="365"
+        src="/images/eventos/240311_gabriel_martin_blazquez.jpg" />
+    </a>
+    <a href="/hackathon-2024/empatia_y_emociones_en_ia" target="_blank">
+        <img alt="Palestra de Amanda Curry" width="650" height="365"
+        src="/images/eventos/240326_amanda_curry.jpg" />
+    </a>
+</div>
+
+## Hackathon 2023
+
+<div class="grid grid-cols-3 gap-8 my-8">
+    <a href="/hackathon-2023/fine-tuning-llms" target="_blank">
+        <img alt="Fine-tuning de grandes modelos de linguagem" width="650" height="365"
+        src="/images/eventos/230320_fine_tuning_llms.jpg" />
+    </a>
+    <a href="/hackathon-2023/deteccion-del-lenguaje-ofensivo" target="_blank">
+        <img alt="Detecção de linguagem ofensiva" width="650" height="365"
+        src="/images/eventos/230404_deteccion_del_lenguaje_ofensivo.jpg" />
+    </a>
+    <a href="/hackathon-2023/evaluacion-con-desacuerdo" target="_blank">
+        <img alt="Avaliação com desacordo" width="650" height="365"
+        src="/images/eventos/230404_evaluacion_con_desacuerdo.jpg" />
+    </a>
+</div>
+
+## Hackathon 2022
+
+<div class="grid grid-cols-3 gap-8 my-8">
+    <a href="https://www.youtube.com/watch?v=GX4l3WhOy4o&list=PLTA-KAy8nxaAbVZ2lVcycHnJ2qEDip7hG" target="_blank">
+        <img alt="Evento 04" width="650" height="365"
+        src="/images/eventos/220323_cristina.png" />
+    </a>
+    <a href="https://www.youtube.com/watch?v=UQwWTykNFW0&list=PLTA-KAy8nxaAbVZ2lVcycHnJ2qEDip7hG" target="_blank">
+        <img alt="Evento 05" width="650" height="365"
+        src="/images/eventos/220323_paulo.png" />
+    </a>
+    <a href="https://www.youtube.com/watch?v=aNR7UM-E6vA&list=PLTA-KAy8nxaAbVZ2lVcycHnJ2qEDip7hG" target="_blank">
+        <img alt="Evento 06" width="650" height="365"
+        src="/images/eventos/220330_ximena.png" />
+    </a>
+</div>
+
+<router-link to="/pt/eventos" class="button-accent max-w-100 mx-auto">
+<Carbon:logoYoutube text="xl" />
+Ver todos os eventos
+</router-link>

--- a/pages/hackathon/index.en.md
+++ b/pages/hackathon/index.en.md
@@ -1,0 +1,445 @@
+---
+title: "#HackathonSomosNLP 2026"
+description: We are going to drive the creation of language models aligned with the culture of LATAM and the Iberian Peninsula.
+lang: en
+cover: /images/eventos/260401_hackathon_sinfecha.jpg
+---
+
+<script setup>
+import HackathonCard from '../../src/components/HackathonCard.vue'
+</script>
+
+There are 600M Spanish speakers and 265M Portuguese speakers in the world. Spanish and Portuguese are the main languages in 29 countries, each of them rich in culture. Although language models show ever-growing multilingual capabilities, are they truly multicultural? Join the #HackathonSomosNLP now, the largest open-source Natural Language Processing hackathon in Spanish and Portuguese 🚀
+
+<div style="display: flex; justify-content: center; gap: 20px; margin-bottom: 30px; margin-top: 30px;">
+  <a href="https://forms.gle/d1WBoTNuNEyzHNi86" target="_blank" style="background-color:#FACC15; color:white; padding:12px 28px; text-decoration:none; border-radius:5px; font-weight:bold; font-size:1.1em;">📝 Register now</a>
+  <a href="https://www.notion.so/Visibilidad-Hackathon-2026-dfbb662bc3d483fe9330812ccece7bbf" target="_blank" style="background-color:#FACC15; color:white; padding:12px 28px; text-decoration:none; border-radius:5px; font-weight:bold; font-size:1.1em;">📣 Spread the word</a>
+</div>
+
+*([In Spanish](https://somosnlp.org/hackathon), [in Portuguese](https://somosnlp.org/pt/hackathon))*
+
+---
+
+## 📊 We're launching the fifth edition!
+
+Since 2022, we have brought together...
+
+<div class="grid grid-cols-2 md:grid-cols-5 gap-4 my-8">
+  <div class="bg-blue-900 text-white rounded-lg p-5 text-center">
+    <div class="text-3xl font-bold">4</div>
+    <div class="text-sm opacity-80 mt-1">Editions</div>
+  </div>
+  <div class="bg-blue-900 text-white rounded-lg p-5 text-center">
+    <div class="text-3xl font-bold">1500+</div>
+    <div class="text-sm opacity-80 mt-1">Participants</div>
+  </div>
+  <div class="bg-blue-900 text-white rounded-lg p-5 text-center">
+    <div class="text-3xl font-bold">30</div>
+    <div class="text-sm opacity-80 mt-1">Countries</div>
+  </div>
+  <div class="bg-blue-900 text-white rounded-lg p-5 text-center">
+    <div class="text-3xl font-bold">100+</div>
+    <div class="text-sm opacity-80 mt-1">Projects</div>
+  </div>
+  <div class="bg-blue-900 text-white rounded-lg p-5 text-center">
+    <div class="text-3xl font-bold">60</div>
+    <div class="text-sm opacity-80 mt-1">Events</div>
+  </div>
+</div>
+
+In this fifth edition we will focus on creating resources that let us **evaluate and improve the cultural adequacy of large language models for each of the LATAM and Iberian Peninsula countries**.
+
+The best part? EVERYONE can contribute! 🎉
+
+![GIF Hackathon #Somos600M](/images/eventos/250401_hackathon.gif)
+<!-- Actualizar al GIF de este año -->
+
+---
+
+## 🚀 How to participate
+
+<div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-2 my-8">
+
+<HackathonCard
+  icon="📚"
+  title="Send questions about your culture to LLMs"
+  description="Ask LLMs questions and choose which ones align best with your culture. Open to everyone!"
+  linkText=""
+  linkUrl=""
+/>
+
+<HackathonCard
+  icon="💻"
+  title="Build a language model"
+  description="Develop an LLM aligned with your culture. Teams of 1–5 people: generate a dataset, align a model and build a demo."
+  linkText=""
+  linkUrl=""
+/>
+</div>
+
+
+<div style="display: flex; justify-content: center; gap: 20px; margin-bottom: 30px; margin-top: 30px;">
+<a href="https://somosnlp.org/en/hackathon/registro" target="_blank" style="background-color:#FACC15; color:white; padding:12px 28px; text-decoration:none; border-radius:5px; font-weight:bold; font-size:1.1em;">📝 Register now</a>
+
+</div>
+
+
+By participating you will have the opportunity to:
+- ✨ Learn through live workshops and talks
+- ✨ Access hundreds of USD in GPU and API credits to build your project
+- ✨ Win prizes worth 1500, 1000 or 500 USD (1st, 2nd and 3rd place)
+- ✨ Earn conference tickets and nominations to the Nova talent network
+- ✨ Get mentored by leading people in the NLP field
+- ✨ Co-author papers at international NLP conferences
+- ✨ Get a participation (or winning team) certificate for the hackathon
+
+<!-- - ✨ Win access to an online AI Master's program -->
+
+Let's go for it!
+
+*Have questions? Check the FAQ and contact info at the bottom of the page.*
+
+---
+
+## 🚀 Other ways to support us
+
+Help us organize this free, non-profit event!
+
+<div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-2 my-8">
+
+<HackathonCard
+  icon="📣"
+  title="Spread the word"
+  description="Help us reach more people with this initiative. After 4 publications we add your logo to the website."
+  linkText="Spread the word"
+  linkUrl="https://somosnlp.org/en/hackathon/patrocinios"
+/>
+
+<HackathonCard
+  icon="🤗"
+  title="Join the team"
+  description="Collaborate by creating content, support resources, tutorials, articles, or by researching Cultural NLP."
+  linkText="Join"
+  linkUrl="https://forms.gle/vjkLRQVnGF5eVgqq5"
+/>
+
+<HackathonCard
+  icon="🧑‍🏫"
+  title="Offer a mentorship"
+  description="Share your experience helping teams build quality datasets and train good LLMs. One-off or ongoing mentorships."
+  linkText="Offer mentorship"
+  linkUrl="https://forms.gle/Cq7CfgxaLTrthZU37"
+/>
+
+<HackathonCard
+  icon="🙌"
+  title="Sponsor the event"
+  description="Support our mission through visibility, vouchers or donations. SomosNLP is a non-profit community."
+  linkText="See options"
+  linkUrl="https://somosnlp.org/en/hackathon/patrocinios"
+/>
+
+</div>
+
+---
+
+## 🏆 Success stories
+
+Hackathon projects generate real-world impact:
+
+<div class="grid gap-5 md:grid-cols-2 my-8">
+
+<div class="border-l-4 border-blue-500 bg-gray-50 dark:bg-gray-800 rounded-r-lg p-5">
+  <div class="flex items-center gap-2 mb-2">
+    <span class="text-xs font-bold bg-blue-500 text-white px-2 py-0.5 rounded">2022</span>
+    <span class="text-xs text-gray-500">1st Prize</span>
+  </div>
+  <h4 class="font-bold text-base mb-1">🏅 BiomedIA</h4>
+  <p class="text-sm text-gray-600 dark:text-gray-400">Voice-to-voice biomedical Q&A system. It led to a <a href="https://research.latinxinai.org/papers/naacl/2022/pdf/paper_06.pdf" target="_blank" class="text-blue-600 underline">paper at NAACL 2022</a> that won the Best Poster Presentation Award.</p>
+</div>
+
+<div class="border-l-4 border-blue-500 bg-gray-50 dark:bg-gray-800 rounded-r-lg p-5">
+  <div class="flex items-center gap-2 mb-2">
+    <span class="text-xs font-bold bg-blue-500 text-white px-2 py-0.5 rounded">2022</span>
+    <span class="text-xs text-gray-500">2nd Prize</span>
+  </div>
+  <h4 class="font-bold text-base mb-1">⚖️ Mexican Legal Model</h4>
+  <p class="text-sm text-gray-600 dark:text-gray-400">Legal knowledge model <strong>used by the Supreme Court of Justice of Mexico</strong>.</p>
+</div>
+
+<!-- #TODO Añadir highlights de 2023 -->
+
+<div class="border-l-4 border-blue-500 bg-gray-50 dark:bg-gray-800 rounded-r-lg p-5">
+  <div class="flex items-center gap-2 mb-2">
+    <span class="text-xs font-bold bg-blue-500 text-white px-2 py-0.5 rounded">2024</span>
+    <span class="text-xs text-gray-500">1st Prize</span>
+  </div>
+  <h4 class="font-bold text-base mb-1">📰 NoticIA</h4>
+  <p class="text-sm text-gray-600 dark:text-gray-400">Corpus of 850 Spanish clickbait news articles with high-quality summaries, tackling digital misinformation. Published at SEPLN 2024.</p>
+</div>
+
+<div class="border-l-4 border-blue-500 bg-gray-50 dark:bg-gray-800 rounded-r-lg p-5">
+  <div class="flex items-center gap-2 mb-2">
+    <span class="text-xs font-bold bg-blue-500 text-white px-2 py-0.5 rounded">2024</span>
+    <span class="text-xs text-gray-500">2nd Prize</span>
+  </div>
+  <h4 class="font-bold text-base mb-1">🤝 AsistenciaRefugiados</h4>
+  <p class="text-sm text-gray-600 dark:text-gray-400">Legal assistant for refugees, making legal information in Spain more accessible.</p>
+</div>
+
+<div class="border-l-4 border-blue-500 bg-gray-50 dark:bg-gray-800 rounded-r-lg p-5">
+  <div class="flex items-center gap-2 mb-2">
+    <span class="text-xs font-bold bg-blue-500 text-white px-2 py-0.5 rounded">2024</span>
+    <span class="text-xs text-gray-500">1st Prize</span>
+  </div>
+  <h4 class="font-bold text-base mb-1">🤝 Sustainable BERT</h4>
+  <p class="text-sm text-gray-600 dark:text-gray-400">Identification of texts related to climate change and sustainability using pre-trained language models in Spanish. LatinX in AI (LXAI) Research Workshop @NAACL 2024. Best paper at KHIPU 2025.</p>
+</div>
+
+<div class="border-l-4 border-blue-500 bg-gray-50 dark:bg-gray-800 rounded-r-lg p-5">
+  <div class="flex items-center gap-2 mb-2">
+    <span class="text-xs font-bold bg-blue-500 text-white px-2 py-0.5 rounded">2024</span>
+    <span class="text-xs text-gray-500">1st Prize</span>
+  </div>
+  <h4 class="font-bold text-base mb-1">🤝 Healthy Cooking</h4>
+  <p class="text-sm text-gray-600 dark:text-gray-400">Learning to cook in healthy ways with Large Language Models, Supervised Fine-Tuning and Retrieval Augmented Generation. LatinX in AI (LXAI) Research Workshop @NAACL 2024.</p>
+</div>
+
+<div class="border-l-4 border-accent-500 bg-gray-50 dark:bg-gray-800 rounded-r-lg p-5 md:col-span-2">
+  <div class="flex items-center gap-2 mb-2">
+    <span class="text-xs font-bold bg-accent-500 text-white px-2 py-0.5 rounded">2024</span>
+    <span class="text-xs text-gray-500">Collective achievement</span>
+  </div>
+  <h4 class="font-bold text-base mb-1">📚 Instruction dataset</h4>
+  <p class="text-sm text-gray-600 dark:text-gray-400">More than 1M instructions generated, creating the largest supervised training dataset in Spanish. #Somos600M paper published at the LatinX in NLP workshop @NAACL 2024. Interview in El País newspaper.</p>
+</div>
+
+<div class="border-l-4 border-accent-500 bg-gray-50 dark:bg-gray-800 rounded-r-lg p-5 md:col-span-2">
+  <div class="flex items-center gap-2 mb-2">
+    <span class="text-xs font-bold bg-accent-500 text-white px-2 py-0.5 rounded">2025</span>
+    <span class="text-xs text-gray-500">Collective achievement</span>
+  </div>
+  <h4 class="font-bold text-base mb-1">📚 INCLUDE: cultural knowledge benchmark</h4>
+  <p class="text-sm text-gray-600 dark:text-gray-400">More than <strong>38,000 exam questions were collected from 23 countries</strong>, creating the largest cultural-knowledge evaluation benchmark for LLMs in Spanish and Portuguese.</p>
+</div>
+
+</div>
+
+<center><a href="/en/hackathon/ediciones-anteriores" style="background-color:#FACC15; color:white; padding:10px 20px; text-decoration:none; border-radius:5px;">More examples</a></center>
+
+---
+
+## 💡 Talks and mentorships
+
+You will have the chance to learn from leaders in academia and industry — we will keep announcing new talks and mentorships!
+
+<SpeakerList :year="2026" :cols="3" />
+
+---
+
+## 👏 Acknowledgments
+
+Thank you so much for your time and for helping our initiative reach further. Let's make language models more inclusive!
+
+### 🚀 Organized by
+
+<div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px 50px; justify-items: center; align-items: center;">
+
+<SponsorInfo sponsor="SomosNLP" url="http://somosnlp.org"
+logo="/images/patrocinios/somosnlp_nobg.png"
+logo_dark="/images/patrocinios/somosnlp_nobg.png" />
+
+<SponsorInfo sponsor="UNED" url="http://somosnlp.org/patrocinios/uned-nlp"
+logo="/images/patrocinios/UNEDNLP.png"
+logo_dark="/images/patrocinios/UNEDNLP.png" />
+
+</div>
+
+<!--
+### 💎 Platinum
+
+<div style="display: grid; grid-template-columns: repeat(1, 1fr); gap: 10px 50px; justify-items: center; align-items: center;">
+
+<SponsorInfo sponsor="Cohere For AI" url=""
+logo="/images/patrocinios/cohere.svg"
+logo_dark="/images/patrocinios/cohere.svg" />
+
+</div>
+-->
+
+### 🥇 Gold Sponsors
+
+<div style="display: grid; grid-template-columns: repeat(5, 1fr); gap: 10px 50px; justify-items: center; align-items: center;">
+
+<SponsorInfo sponsor="NextGenerationEU" url="http://somosnlp.org/patrocinios/NextGenerationEU"
+logo="/images/patrocinios/NextGenerationEU.png"
+logo_dark="/images/patrocinios/NextGenerationEU.png" />
+
+<SponsorInfo sponsor="SEDIA" url="http://somosnlp.org/patrocinios/SEDIA"
+logo="/images/patrocinios/SEDIA.png"
+logo_dark="/images/patrocinios/SEDIA.png" />
+
+<SponsorInfo sponsor="redes" url="http://somosnlp.org/patrocinios/redes"
+logo="/images/patrocinios/redes.png"
+logo_dark="/images/patrocinios/redes.png" />
+
+<SponsorInfo sponsor="PERTE" url="http://somosnlp.org/patrocinios/PERTE"
+logo="/images/patrocinios/PERTE.png"
+logo_dark="/images/patrocinios/PERTE.png" />
+
+<SponsorInfo sponsor="UNED" url="http://somosnlp.org/patrocinios/UNED"
+logo="/images/patrocinios/UNED.png"
+logo_dark="/images/patrocinios/UNED.png" />
+
+</div>
+
+
+<div style="display: grid; grid-template-columns: repeat(1, 1fr); gap: 10px 50px; justify-items: center; align-items: center;">
+
+<SponsorInfo sponsor="Hugging Face" url="http://somosnlp.org/patrocinios/huggingface"
+logo="/images/patrocinios/HuggingFace_title.svg"
+logo_dark="/images/patrocinios/HuggingFace_title.svg" />
+
+</div>
+
+### 🥈 Silver Sponsors
+
+<div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px 50px; justify-items: center; align-items: center;">
+
+<SponsorInfo sponsor="Universidad Politécnica de Madrid" url="http://somosnlp.org/patrocinios/upm"
+logo="/images/patrocinios/UPM.jpeg"
+logo_dark="/images/patrocinios/UPM.jpeg" />
+
+<SponsorInfo sponsor="CENIA" url="http://somosnlp.org/patrocinios/cenia"
+logo="/images/patrocinios/CENIA.jpeg"
+logo_dark="/images/patrocinios/CENIA.jpeg" />
+
+</div>
+
+<!--
+### 🌟 Community Support
+
+<SponsorList type="Comunidad 2026" cols="4" />
+-->
+
+---
+
+## ❓ Frequently asked questions
+
+<details>
+<summary>Why should I participate?</summary>
+
+By joining this hackathon you will have the chance to:
+
+- ✅ Understand how large language models work, both text (LLMs) and multimodal (VLLMs), and discover the challenges of each development stage: corpus creation, training, alignment and evaluation
+- ✅ Take part in building the first high-quality, diverse preference corpus to align LLMs with the cultures of LATAM and the Iberian Peninsula (great experience and great for your CV)
+- ✅ Be part of the team that creates some of the datasets for the first open leaderboard of LLMs in Spanish: La Leaderboard
+- ✅ Get all your NLP questions answered during "Ask Me Anything" mentoring sessions
+- ✅ Get support to present your work in a paper
+- ✅ Win prizes to keep growing as a professional and earn a certificate you can share on LinkedIn
+- ✅ Join the largest community of Spanish speakers studying, working and researching in NLP
+
+</details>
+
+<details>
+<summary>What level is required?</summary>
+
+The SomosNLP team encourages you to participate regardless of your current knowledge. In previous editions we have had groups from research institutes and undergraduate student groups — every project counts!
+
+- 📖 We will run a series of **hands-on workshops** showing you how to build a project so you have a reference example.
+
+<!-- Para calentar puedes visualizar los de la edición anterior:
+
+  - [Fine-tuning LLMs (Manu Romero)](https://somosnlp.org/hackathon-2023/fine-tuning-llms)
+  - [Etiquetado de datos con Argilla (Daniel Vila)](https://somosnlp.org/hackathon-2023/etiquetado-de-datos-con-argilla) -->
+
+- ❓ We will organize **AMAs** (Ask Me Anything) with experts and mentors so they can answer your questions.
+
+</details>
+
+<details>
+<summary>What determines the complexity of the projects?</summary>
+
+We will provide an example of how to create a dataset, train a model and build a demo. It's up to you and your team to decide how much to research and work to improve on the baseline. The difficulty also depends on the use case, the origin of the data, how much time you spend curating it, the training technique, how many iterations you do and how polished you want your demo to be. You are free to choose everything!
+
+</details>
+
+<details>
+<summary>Do we really need 4 weeks?</summary>
+
+No — it depends on your availability, you can develop a good project in a week. We know people have studies and jobs, so we leave more time than strictly necessary so everyone can participate. We also want to give you extra time to enjoy attending the live talks and mentorships held during the hackathon.
+
+</details>
+
+<details>
+<summary>Until when can I create a team?</summary>
+
+UPDATED: We welcome new teams until May 23. The final project submission day is May 31.
+
+</details>
+
+<details>
+<summary>How do I join a team?</summary>
+
+Read the "To create a team:" section at the start of this page and the README in the #encuentra-equipo channel of our Discord server :)
+
+</details>
+
+<details>
+<summary>Can teams be just 1 person?</summary>
+
+Yes, we accept teams of 1 to 5 people.
+
+</details>
+
+<details>
+<summary>How do you recommend organizing ourselves?</summary>
+
+- Use your project's Discord channel to communicate and get organized.
+- Since this is an international hackathon, we recommend async communication or splitting the work and holding smaller meetings
+- Schedule meetings or chat spontaneously using the new voice channels in the "MEETING ROOMS" category on Discord
+- Pin the important messages in your project channel, e.g. task allocation, next meeting date, etc. To pin a message click the three dots and select "Pin message"
+- For extra clarity, you can also create a shared document with the team where you write down the project goal, split tasks and so on (and pin the link in the chat)
+
+</details>
+
+<details>
+<summary>I don't understand Discord — which are the most important channels?</summary>
+
+- Check the [#anuncios](https://discord.com/channels/938134488670675055/944255490748207115) channel — we recommend enabling notifications; we post 2–3 times a week
+- Ask your questions in the Discord [#pide-ayuda](https://discord.com/channels/938134488670675055/1051997272356966430) channel so everyone can benefit from the answer
+- Events are announced in [#eventos](https://discord.com/channels/938134488670675055/939934987581534228) and added to the [Google Calendar](https://calendar.google.com/calendar/u/0?cid=ZWM3MGZhODIzNmYyNzBlMTYwYzFiMjdhNDgzZWMyMjA1ZjQwYzUyN2E5N2MwZTJhZmY0OTcwZDZmZjBkYzQyMEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t)
+
+</details>
+
+<details>
+<summary>How can I find out about the events?</summary>
+
+- We announce events in the [#eventos](https://discord.com/channels/938134488670675055/939934987581534228) channel
+- We add them to the [Google Calendar](https://calendar.google.com/calendar/u/0?cid=ZWM3MGZhODIzNmYyNzBlMTYwYzFiMjdhNDgzZWMyMjA1ZjQwYzUyN2E5N2MwZTJhZmY0OTcwZDZmZjBkYzQyMEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t)
+- We announce them on social media ([LinkedIn](https://www.linkedin.com/company/somosnlp), [X (Twitter)](https://x.com/somosnlp_))
+- [Follow us on YouTube](https://www.youtube.com/c/somosnlp?sub_confirmation=1) and save the [Hackathon 2026 playlist](https://www.youtube.com/playlist?list=PLTA-KAy8nxaDHyJyPlrDMCkwTsJZpMNK6)
+
+</details>
+
+<details>
+<summary>How can I give feedback about the event?</summary>
+
+- You can give us feedback to improve the challenge guides via this [form](https://forms.gle/LjQBb8B3XGqPs8Ws9) (anonymous)
+- We will also share a general feedback form at the end of the event
+
+</details>
+
+
+*If we told you there is info on this page that you can't find, clear the cookies and reload the page.*
+
+---
+
+## 🤗 Connect!
+
+To keep up with all the events and updates:
+- Join the community of 2000+ people on [Discord](https://discord.com/invite/my8w7JUxZR) (it's free!)
+- Keep an eye on the Discord channels [#anuncios](https://discord.com/channels/938134488670675055/944255490748207115) and [#eventos](https://discord.com/channels/938134488670675055/939934987581534228)
+- Follow us on [X](https://x.com/somosnlp_) and [LinkedIn](https://linkedin.com/company/somosnlp)
+- Subscribe to our [YouTube](https://youtube.com/c/somosnlp?sub_confirmation=1) channel
+- Join the [Google Calendar](https://calendar.google.com/calendar/u/0?cid=ZWM3MGZhODIzNmYyNzBlMTYwYzFiMjdhNDgzZWMyMjA1ZjQwYzUyN2E5N2MwZTJhZmY0OTcwZDZmZjBkYzQyMEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t)


### PR DESCRIPTION
Add English and Portuguese co-located translations for cartel.md, ediciones-anteriores.md and the English translation for index.md in the current hackathon edition so visitors landing on /en/hackathon or /pt/hackathon see the full page content in their language.

https://claude.ai/code/session_01Vuk9AQXGTSRLm7mVAe9GYw