### PR TITLE
Add cover image display for community blog posts

### DIFF
--- a/src/components/BlogPost.vue
+++ b/src/components/BlogPost.vue
@@ -73,6 +73,13 @@ const linkUrl = computed(() => `https://www.linkedin.com/sharing/share-offsite/?
             </div>
         </header>
         <hr class="mx-auto mt-8 mb-12 prose" />
+        <div v-if="$route.path.startsWith('/comunidad/') && frontmatter.cover" class="flex justify-center mb-12">
+            <img
+                :src="frontmatter.cover"
+                :alt="frontmatter.title"
+                class="rounded-2xl object-cover w-64 h-64"
+            />
+        </div>
         <!-- Diferenciación necesaria para la correcta visualización de las tablas en recursos -->
         <article v-if="frontmatter.tablePage">
             <slot />


### PR DESCRIPTION
## Summary
Added conditional rendering of cover images for blog posts in the community section. When viewing a post under the `/comunidad/` route that has a cover image defined in its frontmatter, the image is now displayed prominently below the post header.

## Key Changes
- Added a new image container that displays only for community blog posts (`/comunidad/` route) with a cover image
- The cover image is rendered with rounded corners and fixed dimensions (64x64 units) for consistent styling
- Image is centered on the page with bottom margin spacing for proper layout separation from the article content
- Uses the post's title as alt text for accessibility

## Implementation Details
- Conditional rendering uses `v-if` to check both the route path and frontmatter cover property
- Image styling includes `rounded-2xl` for rounded corners and `object-cover` to maintain aspect ratio
- Positioned between the header divider and article content for optimal visual hierarchy

https://claude.ai/code/session_01Ga1PWzXSq6apvYQvVc5dEg